### PR TITLE
Configurable security groups

### DIFF
--- a/gonzo/backends/aws.py
+++ b/gonzo/backends/aws.py
@@ -80,6 +80,11 @@ class Cloud(BaseCloud):
     def list_security_groups(self):
         return self.connection.get_all_security_groups()
 
+    def create_security_groups(self, groups):
+        # ToDo: configurable Rules
+        for sg_name, _ in groups.items():
+            self.create_security_group(sg_name)
+
     def _region(self):
         region_name = config.REGION
         acces_key_id = config.CLOUD['AWS_ACCESS_KEY_ID']

--- a/gonzo/backends/aws.py
+++ b/gonzo/backends/aws.py
@@ -81,7 +81,7 @@ class Cloud(BaseCloud):
         return self.connection.get_all_security_groups()
 
     def create_security_groups(self, groups):
-        # ToDo: configurable Rules
+        # ToDo: configurable Rules for Amazon as well.
         for sg_name, _ in groups.items():
             self.create_security_group(sg_name)
 

--- a/gonzo/backends/base.py
+++ b/gonzo/backends/base.py
@@ -273,10 +273,11 @@ def launch_instance(env_type, username=None):
     zone = cloud.next_az(server_type)
 
     # check that the instance can be associated with a Security Group
-    security_groups = config.CLOUD['SECURITY_GROUPS']
+    security_groups = config.CLOUD.get('SECURITY_GROUPS')
     if not security_groups:
         raise ConfigurationError('Security Group(s) must be defined for every Cloud')
 
+    # this won't raise if any of the Groups or Rules already exist
     cloud.create_security_groups(security_groups)
 
     key_name = config.CLOUD['PUBLIC_KEY_NAME']

--- a/gonzo/backends/openstack.py
+++ b/gonzo/backends/openstack.py
@@ -97,6 +97,9 @@ class Cloud(BaseCloud):
     def list_security_groups(self):
         return self.connection.api.security_groups.list()
 
+    def _list_instance_types(self):
+        return self.connection.api.flavors.list()
+
     def create_security_groups(self, groups):
         """ Creates security groups from Gonzo dict config format """
         existing_groups = self.connection.api.security_groups.list()


### PR DESCRIPTION
*\* Configurable Security Groups **

This is an open source project and users should have more control over their Ingress filtering!
I've been using Gonzo with Devstack and a Group with no Rules blocks all incoming traffic.

Furthermore:
-Users are likely not to want a group called 'Gonzo'.
-Users will want to decide what groups, their names, and what rules are applied, and at what time.
-Users should also be able to set groups without having to launch an instance!

So I've made some very simple changes.

Untested in the wild, only using Devstack.
What do you all think?

This is the addition to my config.py

``` python
        # syntax for defining security groups which do ingress filtering.
        'SECURITY_GROUPS': {
            'development': [
                {'ip_protocol': 'tcp',  # enable http
                 'from_port': 1,
                 'to_port': 65535,
                 # Classless Inter-Domain Routing (method for allocating IP addresses)
                 'cidr': '0.0.0.0/0',},
                {'ip_protocol': 'icmp',  # enable ping
                 'from_port': -1,
                 'to_port': -1,
                 'cidr': '0.0.0.0/24'},
                 {'ip_protocol': 'tcp',  # enable ssh 
                 'from_port': 22,
                 'to_port': 22,
                 'cidr': '0.0.0.0/24'},
            ] 
        },
```
